### PR TITLE
Linktree updates

### DIFF
--- a/_layouts/linktree.html
+++ b/_layouts/linktree.html
@@ -10,9 +10,8 @@
     {% if site.plugins contains 'jekyll-seo-tag' %}
         {% include head-seo.html %}
     {% else %}
-
-    <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html', '' | absolute_url }}">
+        <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+        <link rel="canonical" href="{{ page.url | replace:'index.html', '' | absolute_url }}">
     {% endif %}
 
     <!-- Site Favicon -->
@@ -30,19 +29,19 @@
 {% capture layout %}{% if page.layout %}layout-{{ page.layout }}{% endif %}{% endcapture %}
 
 <body class="{{ layout }}">
+    <canvas id="background-canvas"></canvas>
     <div id="page" class="site">
-      <header class="site-header">
-          <div class="inner">
-              <div class="site-branding">
-                  <h1 class="site-title"><a href="{{ site.baseurl }}/" rel="home">{{site.name}}</a></h1>
-                  <p id="para1" class="site-description"> </p>
-              </div>
-          </div>
+        <header class="site-header">
+            <div class="inner">
+                <div class="site-branding">
+                    <h1 class="site-title"><a href="{{ site.baseurl }}/" rel="home">{{site.name}}</a></h1>
+                    <p id="para1" class="site-description"> </p>
+                </div>
+            </div>
+        </header>
         {{ content }}
-
     </div><!-- .site -->
     <div id="site-overlay" class="site-overlay"></div>
-    <!-- <canvas id="canvas"></canvas> -->
     {% include analytics.html %}
     <!-- Javascript Assets -->
     <script src="{{ site.baseurl }}/assets/js/jquery-3.2.1.min.js"></script>
@@ -50,7 +49,6 @@
     <script src="{{ site.baseurl }}/assets/js/custom.js"></script>
     <script src="{{ site.baseurl }}/assets/js/background.js"></script>
     {% include slider_scripts.html %}
-
 </body>
 
 </html>

--- a/_sass/_general.scss
+++ b/_sass/_general.scss
@@ -997,6 +997,17 @@ time {
 /* LINK TREE
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
+.linktree-link {
+    @extend button;
+    width: 80%;
+    margin: 0 10% 30px;
+    text-align: center;
+
+    &:hover {
+        border: 2px solid $color-accent;
+    }
+}
+
 #background-canvas {
 	z-index: -99;
 	position: absolute;

--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -34,12 +34,18 @@
  }
  
  html {
+     width: 100vw;
+     height: max-content;
      font-size: 100%;
      -ms-text-size-adjust: 100%;
      -webkit-text-size-adjust: 100%;
  }
  
  body {
+     position: relative;
+     width: 100%;
+     height: max-content;
+     min-height: 100vh;
      margin: 0;
  }
  

--- a/assets/js/background.js
+++ b/assets/js/background.js
@@ -3,172 +3,157 @@ const fragShaderSource =
 const vertShaderSource =
   "attribute vec2 a_position;\nvoid main() {\n  gl_Position = vec4(a_position, 0, 1);\n}";
 
-// We're going to use `then` to track the delta between rendered frames
-let then = 0;
-// And we're going to use `strikes` to track how many times the
-// frame delta exceeds the tolerance.
-let strikes = -1;
-const tolerance = 100;
+// Global variables
+const FRAME_DELTA_TOLERANCE = 100;
+let LAST_FRAME_TIME = 0;
+let FPS_DROPS = 0;
+let INITIAL_URL;
+let CURRENT_URL;
+let CURRENT_WINDOW_WIDTH;
+let CURRENT_WINDOW_HEIGHT;
 
-// Tracking the URL changes to reset performance checkers on page changes
-let url;
-let initialUrl;
+function stopDrawing() {
+  if (CURRENT_FRAME_ID) {
+    window.cancelAnimationFrame(CURRENT_FRAME_ID);
+    CURRENT_FRAME_ID = undefined;
+  }
+}
 
-function init(canvas) {
-  initialUrl = url = window.location.toString();
-  // These values will be mutated according to whether or not we can use
-  // OffscreenCanvas
-  let glCanvas;
-  let ctx;
+function startDrawing(canvas) {
+  INITIAL_URL = CURRENT_URL = window.location.toString();
 
   const { clientWidth, clientHeight } = canvas;
   canvas.width = clientWidth;
   canvas.height = clientHeight;
-  glCanvas = document.createElement("canvas");
-  glCanvas.width = canvas.width;
-  glCanvas.height = canvas.height;
-  ctx = canvas.getContext("2d");
 
-  const gl = glCanvas.getContext("webgl");
-  gl.viewport(0, 0, canvas.width, canvas.height);
+  const context = canvas.getContext("webgl");
+  if (!context) {
+    console.warn('WebGL canvas is not supported, aborting initialisation of background animation.');
+    return;
+  }
+  context.viewport(0, 0, canvas.width, canvas.height);
 
-  // Create the buffer
-  // This buffer just renders two triangles as a rectangle the size of the
-  // canvas
-  const buffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER,
+  // Create the buffer - this buffer just renders two triangles as a rectangle the size of the canvas
+  const buffer = context.createBuffer();
+  context.bindBuffer(context.ARRAY_BUFFER, buffer);
+  context.bufferData(
+    context.ARRAY_BUFFER,
     new Float32Array([
       -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 1.0,
     ]),
-    gl.STATIC_DRAW
+    context.STATIC_DRAW
   );
 
   // Create the shaders
-  // This vertex shader is dead simple and just returns its input attribute
-  const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vertexShader, vertShaderSource);
-  gl.compileShader(vertexShader);
-
-  // The fragment shader does a bunch of cool stuff, mostly rotating points,
-  // coloring them, and constraining the output colors
-  const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fragmentShader, fragShaderSource);
-  gl.compileShader(fragmentShader);
+  const vertexShader = context.createShader(context.VERTEX_SHADER);
+  context.shaderSource(vertexShader, vertShaderSource);
+  context.compileShader(vertexShader);
+  const fragmentShader = context.createShader(context.FRAGMENT_SHADER);
+  context.shaderSource(fragmentShader, fragShaderSource);
+  context.compileShader(fragmentShader);
 
   // Connect the shaders and program to the renderer
-  const program = gl.createProgram();
-  gl.attachShader(program, vertexShader);
-  gl.attachShader(program, fragmentShader);
-  gl.linkProgram(program);
-  gl.useProgram(program);
+  const program = context.createProgram();
+  context.attachShader(program, vertexShader);
+  context.attachShader(program, fragmentShader);
+  context.linkProgram(program);
+  context.useProgram(program);
 
   // Delete components early to improve performance
-  gl.deleteShader(vertexShader);
-  gl.deleteShader(fragmentShader);
-  gl.deleteProgram(program);
+  context.deleteShader(vertexShader);
+  context.deleteShader(fragmentShader);
+  context.deleteProgram(program);
 
   // Connect to the position attribute for the vertex shader
-  const positionLocation = gl.getAttribLocation(program, "a_position");
-  gl.enableVertexAttribArray(positionLocation);
+  const positionLocation = context.getAttribLocation(program, "a_position");
+  context.enableVertexAttribArray(positionLocation);
 
   // Set the resolution uniform and create a connection to the time uniform
-  const resolution = [canvas.clientWidth, canvas.clientHeight];
-  const resolutionPosition = gl.getUniformLocation(program, "u_resolution");
-  const timePosition = gl.getUniformLocation(program, "u_time");
-  const shouldInvertPosition = gl.getUniformLocation(program, "u_shouldInvert");
+  const resolution = [canvas.width, canvas.height];
+  const resolutionPosition = context.getUniformLocation(program, "u_resolution");
+  const timePosition = context.getUniformLocation(program, "u_time");
+  const shouldInvertPosition = context.getUniformLocation(program, "u_shouldInvert");
   const mql = window.matchMedia("(prefers-color-scheme: dark)");
   let shouldInvert = !mql.matches;
-
-  mql.addEventListener("change", (e) => (shouldInvert = !e.matches));
+  mql.addEventListener("change", (e) => {
+    shouldInvert = !e.matches;
+  });
 
   // Reset the spike counter when focusing away since requestAnimationFrame
   // doesn't tick on inactive windows anyway
   document.addEventListener(
     "visibilitychange",
-    () => (strikes = document.hidden ? -1 : strikes)
+    () => {
+      if (!document.hidden) return;
+      FPS_DROPS = 0;
+    }
   );
 
-  // The main render loop
+  /* The main render loop */
   // First, we'll start a random seed to create a different starting scene on
   // each canvas mount
   const seed = Math.round(Math.random() * 20000);
 
-  let running = true;
+  function render(currentFrameTime) {
+    const framesDelta = currentFrameTime - LAST_FRAME_TIME;
+    LAST_FRAME_TIME = currentFrameTime;
 
-  function render(now) {
-    // Early in the loop, we'll do some performance monitoring.
-    const diff = now - then;
-    then = now;
-
-    // If the loop is lagging and the document is in focus, keep lags below
-    // three strikes
-    if (diff > tolerance && document.hasFocus()) {
-      url = window.location.toString();
-
-      // Only if the page URL has changed do we really need to worry about
+    // If the loop is lagging and the document is in focus,
+    // mark it as an FPS drop
+    if (framesDelta > FRAME_DELTA_TOLERANCE && document.hasFocus()) {
+      CURRENT_URL = window.location.toString();
+      // Only if the page URL hasn't changed do we really need to worry about
       // FPS spikes
-      if (url === initialUrl) {
-        strikes++;
+      if (CURRENT_URL === INITIAL_URL) {
+        FPS_DROPS += 1;
       } else {
         // Otherwise, reset the spike counter ready for the next mount
-        strikes = -1;
+        FPS_DROPS = -1;
       }
     }
 
     // Three strikes and we're out
-    if (strikes >= 3) {
-      cancelLoop();
+    if (FPS_DROPS >= 3) {
+      stopDrawing();
       return;
     }
 
     // Clear GLSL canvas
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    context.clear(context.COLOR_BUFFER_BIT);
 
     // Update GLSL attributes and uniforms
-    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform2fv(resolutionPosition, resolution);
-    gl.uniform1f(timePosition, now / 2000.0 + seed);
-    gl.uniform1i(shouldInvertPosition, Number(shouldInvert));
+    context.vertexAttribPointer(positionLocation, 2, context.FLOAT, false, 0, 0);
+    context.uniform2fv(resolutionPosition, resolution);
+    context.uniform1f(timePosition, currentFrameTime / 2000.0 + seed);
+    context.uniform1i(shouldInvertPosition, Number(shouldInvert));
 
     // Draw arrays
-    gl.drawArrays(gl.TRIANGLES, 0, 6);
+    context.drawArrays(context.TRIANGLES, 0, 6);
 
-    // Output image to canvas
-    const castContext = ctx;
-    castContext.drawImage(gl.canvas, 0, 0);
-
-    // Call the render loop again before the next pain cycle
-    if (running) {
-      window.requestAnimationFrame(render);
-    }
+    CURRENT_FRAME_ID = window.requestAnimationFrame(render);
   }
 
-  function cancelLoop() {
-    running = false;
-  }
-
-  // Kick off our render loop
   render(0);
-
-  return cancelLoop;
 }
 
-const canvas = document.querySelector("#background-canvas");
+window.addEventListener('DOMContentLoaded', () => {
+  const canvas = document.querySelector("#background-canvas");
 
-if (!canvas) {
-  throw new Error("Background canvas not found");
-} else {
-  let canceller;
-  window.addEventListener("DOMContentLoaded", () => (canceller = init(canvas)));
+  if (!canvas) {
+    throw new Error("Background canvas not found");
+  } else {
+    startDrawing(canvas);
 
-  window.addEventListener("resize", () => {
-    if (!canceller) {
-      return;
-    }
-
-    canceller();
-    canceller = init(canvas);
-  });
-}
+    CURRENT_WINDOW_WIDTH = window.clientWidth;
+    CURRENT_WINDOW_HEIGHT = window.clientHeight;
+    window.addEventListener("resize", () => {
+      const shouldRestart = CURRENT_WINDOW_WIDTH !== window.clientWidth || CURRENT_WINDOW_HEIGHT !== window.clientHeight;
+      if (shouldRestart) {
+        CURRENT_WINDOW_WIDTH = window.clientWidth;
+        CURRENT_WINDOW_HEIGHT = window.clientHeight;
+        stopDrawing();
+        startDrawing(canvas);
+      }
+    });
+  }
+})

--- a/linktree.md
+++ b/linktree.md
@@ -3,28 +3,22 @@ layout: linktree
 title: Link Tree
 ---
 
-<canvas id="background-canvas"></canvas>
-
-<div class="entry-header">
-<div class="col-xs-12">
-            <div style="padding-bottom: 30px;">
-                <button onclick="location.href='https://jamesmilton.me'" type="button" class="shake" style="width: 80%" target="_blank">Website 🌐</button>
-            </div>
-
-            <div style="padding-bottom: 30px;">
-                <button onclick="location.href='https://www.instagram.com/james.jpg/'" type="button" style="width: 80%;" target="_blank">Instagram 📸</button>
-            </div>
-
-            <div style="padding-bottom: 30px;">
-                <button onclick="location.href='https://www.youtube.com/channel/UC4G3WR8U8Uk0OY62jD1Ut_w'" type="button" style="width: 80%;" target="_blank">YouTube 📹</button>
-            </div>
-
-            <div style="padding-bottom: 30px;">
-                <button onclick="location.href='https://twitter.com/jmltn'" type="button" style="width: 80%;" target="_blank">Twitter 🐦</button>
-            </div>
-
-            <div style="padding-bottom: 30px;">
-                <button onclick="location.href='https://www.linkedin.com/in/jmltn/'" type="button" style="width: 80%;" target="_blank">LinkedIn 💼</button>
-            </div>
-</div>
+<div class="entry-content">
+    <div class="col-xs-12">
+        <a href="https://jamesmilton.me" target="_blank" class="linktree-link shake">
+            Website 🌐
+        </a>
+        <a href="https://www.instagram.com/james.jpg/" target="_blank" class="linktree-link">
+            Instagram 📸
+        </a>
+        <a href="https://www.youtube.com/channel/UC4G3WR8U8Uk0OY62jD1Ut_w" target="_blank" class="linktree-link">
+            YouTube 📹
+        </a>
+        <a href="https://twitter.com/jmltn" target="_blank" class="linktree-link">
+            Twitter 🐦
+        </a>
+        <a href="https://www.linkedin.com/in/jmltn/" target="_blank" class="linktree-link">
+            LinkedIn 💼
+        </a>
+    </div>
 </div>


### PR DESCRIPTION
Add missing closing `header` tag in linktree layout.

Fix issue in `linktree.md` issue where we get unnecessary whitespace due
to the `margin-bottom` set on `entry-header`.

Replace linktree buttons with anchors so we can actually open
them in new tabs and for improved SEO / accessibility.
Add styling for these links to match the buttons.

Fix issue where the linktree canvas only covers part of the screen on
short screens (i.e. landscape mobiles).

Update background canvas script to check that the windows width / height
has changed before restarting the animation.
This is needed because mobile browsers collapse the address bar when
the user scrolls down and fire a `resize` event even though the
window doesn't change size.

Minor refactor of `background.js`.